### PR TITLE
Initial Adobe Portfolio templates

### DIFF
--- a/portfolio.adobe.com.prod.json
+++ b/portfolio.adobe.com.prod.json
@@ -1,0 +1,40 @@
+{
+  "providerId":"portfolio.adobe.com",
+  "providerName":"Adobe Portfolio",
+  "serviceId":"prod",
+  "serviceName":"Adobe Portfolio Websites",
+  "version":1,
+  "description":"Enables a domain to work with Adobe Portfolio",
+  "records":[
+    {
+      "type":"CNAME",
+      "host": "www",
+      "pointsTo":"@",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.0.119",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.64.119",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.128.119",
+      "ttl":3600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.192.119",
+      "ttl":3600
+    }
+  ]
+}

--- a/portfolio.adobe.com.stage.json
+++ b/portfolio.adobe.com.stage.json
@@ -1,0 +1,40 @@
+{
+  "providerId":"portfolio.adobe.com",
+  "providerName":"Adobe Portfolio",
+  "serviceId":"stage",
+  "serviceName":"Adobe Portfolio Stage Websites",
+  "version":1,
+  "description":"Enables a domain to work with Adobe Portfolio",
+  "records":[
+    {
+      "type":"CNAME",
+      "host": "www",
+      "pointsTo":"@",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.0.118",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.64.118",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.128.118",
+      "ttl":600
+    },
+    {
+      "type":"A",
+      "host":"@",
+      "pointsTo":"151.101.192.118",
+      "ttl":600
+    }
+  ]
+}


### PR DESCRIPTION
Portfolio templates for Domain Connect. These provide Domain Connect-enabled DNS providers to show users info about which service they are connecting their URL to, and have the IP address info needed to connect a URL to a user's Portfolio site.

We do test connecting domains to Portfolio sites on stage, so we're including a stage template alongside a production template, with each containing the IP addresses we use in each environment.

We plan to add a `logoUrl` once we have that hosted somewhere.