### PR TITLE
Updated serviceName

### DIFF
--- a/portfolio.adobe.com.prod.json
+++ b/portfolio.adobe.com.prod.json
@@ -2,7 +2,7 @@
   "providerId":"portfolio.adobe.com",
   "providerName":"Adobe Portfolio",
   "serviceId":"prod",
-  "serviceName":"Adobe Portfolio Websites",
+  "serviceName":"Portfolio Site",
   "version":1,
   "description":"Enables a domain to work with Adobe Portfolio",
   "records":[

--- a/portfolio.adobe.com.stage.json
+++ b/portfolio.adobe.com.stage.json
@@ -2,7 +2,7 @@
   "providerId":"portfolio.adobe.com",
   "providerName":"Adobe Portfolio",
   "serviceId":"stage",
-  "serviceName":"Adobe Portfolio Stage Websites",
+  "serviceName":"Portfolio Stage Site",
   "version":1,
   "description":"Enables a domain to work with Adobe Portfolio",
   "records":[


### PR DESCRIPTION
Changing the `serviceName` to something less redundant. 

Based on assumption that the DNS provider's confirmation screen has wording like this:

![1and1-confirm](https://user-images.githubusercontent.com/16194195/66681472-d0673e80-ec40-11e9-9fb3-00eaca096849.png)
