### PR TITLE
Portfolio Logo + represent TXT data as key=val

### DIFF
--- a/portfolio.adobe.com.prod.json
+++ b/portfolio.adobe.com.prod.json
@@ -4,6 +4,7 @@
   "serviceId":"prod",
   "serviceName":"Portfolio Site",
   "version":1,
+  "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2019/10/adobe-portfolio-logo-300x54.png",
   "description":"Enables a domain to work with Adobe Portfolio",
   "warnPhishing": true,
   "records":[

--- a/portfolio.adobe.com.prod.json
+++ b/portfolio.adobe.com.prod.json
@@ -6,7 +6,6 @@
   "version":1,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2019/10/adobe-portfolio-logo-300x54.png",
   "description":"Enables a domain to work with Adobe Portfolio",
-  "warnPhishing": true,
   "records":[
     {
       "type":"CNAME",
@@ -16,8 +15,8 @@
     },
     {
       "type":"TXT",
-      "host":"@",
-      "data": "%uuid%",
+      "host":"_portfolio",
+      "data": "verify=%uuid%",
       "ttl":3600
     },
     {

--- a/portfolio.adobe.com.stage.json
+++ b/portfolio.adobe.com.stage.json
@@ -4,6 +4,7 @@
   "serviceId":"stage",
   "serviceName":"Portfolio Stage Site",
   "version":1,
+  "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2019/10/adobe-portfolio-logo-300x54.png",
   "description":"Enables a domain to work with Adobe Portfolio",
   "warnPhishing": true,
   "records":[

--- a/portfolio.adobe.com.stage.json
+++ b/portfolio.adobe.com.stage.json
@@ -6,7 +6,6 @@
   "version":1,
   "logoUrl": "https://www.domainconnect.org/wp-content/uploads/2019/10/adobe-portfolio-logo-300x54.png",
   "description":"Enables a domain to work with Adobe Portfolio",
-  "warnPhishing": true,
   "records":[
     {
       "type":"CNAME",
@@ -16,9 +15,9 @@
     },
     {
       "type":"TXT",
-      "host":"@",
-      "data": "%uuid%",
-      "ttl":3600
+      "host":"_portfolio",
+      "data": "verify=%uuid%",
+      "ttl":600
     },
     {
       "type":"A",


### PR DESCRIPTION
1. Adding the hosted Portfolio logo URL to our template data.

2. As per the recommendations of the Domain Connect maintainers here https://github.com/Domain-Connect/Templates/pull/92, it's preferred that the content of the TXT record is not entirely variable. So we'll be representing it as key=%value% We're also associating it with a subdomain rather than the root host.